### PR TITLE
Add treesitter queries for outline, brackets and indents

### DIFF
--- a/languages/verilog/brackets.scm
+++ b/languages/verilog/brackets.scm
@@ -1,0 +1,5 @@
+("{" @open "}" @close)
+("[" @open "]" @close)
+("(" @open ")" @close)
+("\"" @open "\"" @close)
+("begin" @open "end" @close)

--- a/languages/verilog/indents.scm
+++ b/languages/verilog/indents.scm
@@ -1,0 +1,3 @@
+(_ "{" "}" @end) @indent
+(_ "(" ")" @end) @indent
+(_ "begin" "end" @end) @indent

--- a/languages/verilog/outline.scm
+++ b/languages/verilog/outline.scm
@@ -1,0 +1,91 @@
+; Modules
+(module_declaration
+    (module_ansi_header
+        (module_keyword) @context
+        name: (_) @name)) @item
+
+; Always blocks
+(always_construct
+  (always_keyword) @context
+  (statement
+    (statement_item
+      (seq_block (simple_identifier) @name)?
+      (procedural_timing_control_statement
+        (statement_or_null
+          (statement
+            (statement_item (seq_block (simple_identifier) @name)))))?)
+    )) @item
+
+; for(genvar ...)
+(loop_generate_construct
+  "for" @context
+  (genvar_initialization (simple_identifier) @context.extra)
+  (generate_block name: (_) @name)?) @item
+
+; Module instances
+(module_instantiation
+   instance_type: (_) @context
+   (hierarchical_instance
+     (name_of_instance
+     instance_name: (_) @name))) @item
+
+; Typedefs
+(type_declaration
+  "typedef" @context
+  type_name: (_) @name) @item
+
+; Struct and union members
+(struct_union_member
+  (data_type_or_void (data_type)? @context)
+  (list_of_variable_decl_assignments) @name
+  ) @item
+
+; Initial blocks
+(initial_construct
+  "initial" @context
+  (statement_or_null
+    (statement
+      (statement_item
+        (seq_block
+          (simple_identifier) @name)?)))) @item
+
+; Classes
+(class_declaration
+  "class" @context
+  name: (_) @name
+) @item
+
+; Class properties
+(class_property
+  (data_declaration
+    (data_type_or_implicit) @context
+    (list_of_variable_decl_assignments) @name)) @item
+
+; Functions and tasks,
+; either as class methods
+; or in any other place
+(
+  "extern"? @context
+  (method_qualifier)? @context
+  [
+   (function_declaration
+     "function" @context
+     (lifetime)? @context
+     (function_body_declaration
+       (data_type_or_void) @context
+       (class_scope)? @name
+       name: (_) @name)
+     )
+   (function_prototype
+     "function" @context
+     (data_type_or_void) @context
+     name: (_) @name)
+   (task_prototype
+     "task" @context
+     name: (_) @name)
+   (task_declaration
+     "task" @context
+     (task_body_declaration
+       (class_scope)? @name
+       name: (_) @name))
+   ]) @item

--- a/src/language_server/verible.rs
+++ b/src/language_server/verible.rs
@@ -70,7 +70,7 @@ impl LanguageServer for Verible {
             .ok_or(format!("no asset found matching `{asset_name}`"))?;
         let binary_path = Self::binary_path(&release.version, os, arch)?;
 
-        if !fs::metadata(&binary_path).map_or(false, |metadata| metadata.is_file()) {
+        if !fs::metadata(&binary_path).is_ok_and(|metadata| metadata.is_file()) {
             zed::set_language_server_installation_status(
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
@@ -101,7 +101,7 @@ impl LanguageServer for Verible {
         worktree: &zed::Worktree,
     ) -> zed::Result<String> {
         if let Some(path) = &self.cached_binary {
-            if !fs::metadata(path).map_or(false, |metadata| metadata.is_file()) {
+            if !fs::metadata(path).is_ok_and(|metadata| metadata.is_file()) {
                 self.cached_binary = None;
             } else {
                 return Ok(path.to_string());

--- a/src/language_server/veridian.rs
+++ b/src/language_server/veridian.rs
@@ -67,7 +67,7 @@ impl LanguageServer for Veridian {
             .ok_or(format!("no asset found matching `{asset_name}`"))?;
         let binary_path = Self::binary_path(&release.version, os, arch)?;
 
-        if !fs::metadata(&binary_path).map_or(false, |metadata| metadata.is_file()) {
+        if !fs::metadata(&binary_path).is_ok_and(|metadata| metadata.is_file()) {
             zed::set_language_server_installation_status(
                 language_server_id,
                 &zed::LanguageServerInstallationStatus::Downloading,
@@ -98,7 +98,7 @@ impl LanguageServer for Veridian {
         worktree: &zed_extension_api::Worktree,
     ) -> zed_extension_api::Result<String> {
         if let Some(path) = &self.cached_binary {
-            if !fs::metadata(path).map_or(false, |metadata| metadata.is_file()) {
+            if !fs::metadata(path).is_ok_and(|metadata| metadata.is_file()) {
                 self.cached_binary = None;
             } else {
                 return Ok(path.to_string());


### PR DESCRIPTION
Adds queries as defined in the zed documentation.

The outline is more or less complete for RTL code + classes, missing covergroups and probably many other things.
I could not get `generate if/else` working properly, as the nesting in the syntax made them display weirdly in the tree.
The `indents.scm` now makes newly-created `begin/end` blocks be auto-indented inside.