### PR TITLE
Updated DOWNLOAD_TAG for Veridian server

### DIFF
--- a/src/language_server/veridian.rs
+++ b/src/language_server/veridian.rs
@@ -10,7 +10,7 @@ pub struct Veridian {
 impl LanguageServer for Veridian {
     const LANGUAGE_SERVER_ID: &'static str = "veridian";
     const DOWNLOAD_REPO: &'static str = "someone13574/zed-verilog-extension";
-    const DOWNLOAD_TAG: &'static str = "v0.0.5";
+    const DOWNLOAD_TAG: &'static str = "v0.0.7";
 
     fn binary_name(os: zed_extension_api::Os) -> String {
         match os {


### PR DESCRIPTION
Hi,

Great simple plugin! Appreciate your work on this. When checking the code, I noticed that the `DOWNLOAD_TAG` for veridian (in `src/language_server/veridian.rs`) was left as 0.0.5 when there was a 0.0.7 release on your repo. This pull request just updates that string.

Thanks,