### PR TITLE
Update verdian builds to use musl

### DIFF
--- a/.github/workflows/build-veridian.yaml
+++ b/.github/workflows/build-veridian.yaml
@@ -18,21 +18,21 @@ jobs:
         uses: "dtolnay/rust-toolchain@v1"
         with:
           toolchain: stable
-          targets: x86_64-unknown-linux-gnu
+          targets: x86_64-unknown-linux-musl
 
       - name: Run cargo build
-        run: cargo build --release --target=x86_64-unknown-linux-gnu
+        run: cargo build --release --target=x86_64-unknown-linux-musl
 
       - name: Create archive
         run: |
-          mv target/x86_64-unknown-linux-gnu/release/veridian veridian
+          mv target/x86_64-unknown-linux-musl/release/veridian veridian
           strip veridian
-          tar -czvf veridian-x86_64-linux-gnu.tar.gz veridian
+          tar -czvf veridian-x86_64-linux-musl.tar.gz veridian
 
       - name: Add asset to release
         uses: softprops/action-gh-release@v1
         with:
-          files: veridian-x86_64-linux-gnu.tar.gz
+          files: veridian-x86_64-linux-musl.tar.gz
 
   build-linux-aarch64:
     runs-on: ubuntu-latest
@@ -46,27 +46,25 @@ jobs:
         uses: "dtolnay/rust-toolchain@v1"
         with:
           toolchain: stable
-          targets: aarch64-unknown-linux-gnu
+          targets: aarch64-unknown-linux-musl
 
       - name: Install aarch64 compiler
-        run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu -y
+        run: sudo apt-get install gcc-aarch64-linux-gnu g++-aarch64-linux-gnu musl-tools -y
 
       - name: Run cargo build
         env:
-          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_GNU_LINKER: aarch64-linux-gnu-gcc
-          CC_aarch64_unknown_linux_gnu: aarch64-linux-gnu-gcc
-          CXX_aarch64_unknown_linux_gnu: aarch64-linux-gnu-g++
-        run: cargo build --release --target=aarch64-unknown-linux-gnu
+          CARGO_TARGET_AARCH64_UNKNOWN_LINUX_MUSL_LINKER: aarch64-linux-gnu-gcc
+        run: cargo build --release --target=aarch64-unknown-linux-musl
 
       - name: Create archive
         run: |
-          mv target/aarch64-unknown-linux-gnu/release/veridian veridian
-          tar -czvf veridian-aarch64-linux-gnu.tar.gz veridian
+          mv target/aarch64-unknown-linux-musl/release/veridian veridian
+          tar -czvf veridian-aarch64-linux-musl.tar.gz veridian
 
       - name: Add asset to release
         uses: softprops/action-gh-release@v1
         with:
-          files: veridian-aarch64-linux-gnu.tar.gz
+          files: veridian-aarch64-linux-musl.tar.gz
 
   build-macos-x86_64:
     runs-on: macos-latest

--- a/src/language_server/veridian.rs
+++ b/src/language_server/veridian.rs
@@ -36,8 +36,8 @@ impl LanguageServer for Veridian {
         Ok(match (os, arch) {
             (zed::Os::Mac, zed::Architecture::Aarch64) => "veridian-aarch64-macos.tar.gz",
             (zed::Os::Mac, zed::Architecture::X8664) => "veridian-aarch64-x86_64-macos.tar.gz",
-            (zed::Os::Linux, zed::Architecture::Aarch64) => "veridian-aarch64-linux-gnu.tar.gz",
-            (zed::Os::Linux, zed::Architecture::X8664) => "veridian-x86_64-linux-gnu.tar.gz",
+            (zed::Os::Linux, zed::Architecture::Aarch64) => "veridian-aarch64-linux-musl.tar.gz",
+            (zed::Os::Linux, zed::Architecture::X8664) => "veridian-x86_64-linux-musl.tar.gz",
             (zed::Os::Windows, zed::Architecture::X8664) => "veridian-x86_64-windows-mscv.zip",
             (os, arch) => {
                 return Err(format!("architecture {arch:?} not supported on {os:?}"));


### PR DESCRIPTION
Allows veridian to run in linux distros with old glibc versions, which are commonly used for EDA development.