### PR TITLE
Fix comment highlights

### DIFF
--- a/languages/systemverilog/highlights.scm
+++ b/languages/systemverilog/highlights.scm
@@ -246,7 +246,7 @@
   "directive_include"
 ] @keyword.import
 
-(comment) @comment @spell
+(comment) @comment
 
 [
   "@"


### PR DESCRIPTION
Seems like the extra @spell attribute was breaking the parsing

Closes #13