### PR TITLE
Fix injection language for macros

### DIFF
--- a/languages/systemverilog/injections.scm
+++ b/languages/systemverilog/injections.scm
@@ -5,4 +5,4 @@
   (#set! injection.language "comment"))
 
 ((macro_text) @injection.content
-  (#set! injection.language "verilog"))
+  (#set! injection.language "SystemVerilog"))


### PR DESCRIPTION
Setting it to `SystemVerilog` correctly highlights the macro text