### PR TITLE
Let Verible read a .rules.verible_lint file from the worktree

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -49,7 +49,7 @@ impl zed::Extension for VerilogExtension {
                         "--indentation_spaces".to_string(),
                         language_settings.tab_size.to_string(),
                         "--rules_config".to_string(),
-                        worktree.root_path() + "/.rules.verible_lint"
+                        worktree.root_path() + "/.rules.verible_lint",
                     ],
                     env: Vec::new(),
                 })


### PR DESCRIPTION
I wanted to change the lint settings but it wasn't possible before, so this change allows you to use a .rules.verible_lint file as described in https://github.com/chipsalliance/verible/blob/master/verible/verilog/tools/ls/README.md