### PR TITLE
Bump slang-server to 0.2.2

### DIFF
--- a/src/language_server/slang.rs
+++ b/src/language_server/slang.rs
@@ -9,7 +9,7 @@ pub struct Slang {
 impl LanguageServer for Slang {
     const LANGUAGE_SERVER_ID: &'static str = "slang";
     const DOWNLOAD_REPO: &'static str = "hudson-trading/slang-server";
-    const DOWNLOAD_TAG: &'static str = "v0.2.1";
+    const DOWNLOAD_TAG: &'static str = "v0.2.2";
 
     fn get_cached_binary(&self) -> Option<String> {
         self.cached_binary.clone()


### PR DESCRIPTION
* Fixes diagnostics being reported in non-verilog files
* Improves formatting of hover information
* The indexer now correctly handles files updated outside the editor (e.g. git)

Maybe can be enabled by default with the latest fixes?