### PR TITLE
treewide: add supprort for svls

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Adds Verilog and SystemVerilog support for [Zed](https://zed.dev/).
 
 ## Language Servers
 
-This extension has three language servers: [Verible](https://github.com/chipsalliance/verible), [Veridian](https://github.com/vivekmalneedi/veridian), and [slang-server](https://github.com/hudson-trading/slang-server). **By default, only Verible and Veridian are enabled** due to slang-server being relatively new and having an issue where it produces errors on non-verilog files. To enable slang-server, add the following to your settings file:
+This extension has four language servers: [Verible](https://github.com/chipsalliance/verible), [Veridian](https://github.com/vivekmalneedi/veridian), [slang-server](https://github.com/hudson-trading/slang-server), and [svls](https://github.com/dalance/svls). **By default, only Verible and Veridian are enabled** due to slang-server being relatively new and having an issue where it produces errors on non-verilog files. To enable slang-server or svls, add the following to your settings file:
 
 ```json
 "languages": {
@@ -38,6 +38,12 @@ Secondly, you can configure the veridian language server by creating a `veridian
 
 > [!NOTE]
 > Since this extension doesn't use the verible language server through veridian, verible specific settings in `veridian.yml` will not work.
+
+> [!NOTE]
+> svls requires a `.svls.toml` file at your project root to enable linting.
+> Without it, the linter is silently disabled.
+> To customize liniting rules, you will also need a `.svlint.toml` file.
+> See the [svls documentation](https://github.com/dalance/svls#configuration) for details.
 
 ## License
 

--- a/extension.toml
+++ b/extension.toml
@@ -18,6 +18,10 @@ languages = ["Verilog", "SystemVerilog"]
 name = "Slang"
 languages = ["Verilog", "SystemVerilog"]
 
+[language_servers.svls]
+name = "svls"
+languages = ["Verilog", "SystemVerilog"]
+
 [grammars.systemverilog]
 repository = "https://github.com/gmlarumbe/tree-sitter-systemverilog"
 commit = "e88937e66adc3ee7be0bfe40b7e937eafe4212bb"

--- a/src/language_server/mod.rs
+++ b/src/language_server/mod.rs
@@ -1,4 +1,5 @@
 pub mod slang;
+pub mod svls;
 pub mod verible;
 pub mod veridian;
 

--- a/src/language_server/svls.rs
+++ b/src/language_server/svls.rs
@@ -1,0 +1,104 @@
+use super::LanguageServer;
+use std::fs;
+use zed_extension_api::{self as zed};
+
+#[derive(Default)]
+pub struct Svls {
+    cached_binary: Option<String>,
+}
+
+impl LanguageServer for Svls {
+    const LANGUAGE_SERVER_ID: &'static str = "svls";
+    const DOWNLOAD_REPO: &'static str = "dalance/svls";
+    const DOWNLOAD_TAG: &'static str = "v0.2.14";
+
+    fn get_cached_binary(&self) -> Option<String> {
+        self.cached_binary.clone()
+    }
+
+    fn set_cached_binary(&mut self, cached_bin: Option<String>) {
+        self.cached_binary = cached_bin;
+    }
+
+    fn binary_name(os: zed_extension_api::Os) -> String {
+        match os {
+            zed::Os::Mac | zed::Os::Linux => "svls",
+            zed::Os::Windows => "svls.exe",
+        }
+        .to_string()
+    }
+
+    fn binary_path(
+        _version: &str,
+        _os: zed_extension_api::Os,
+        _arch: zed_extension_api::Architecture,
+    ) -> zed_extension_api::Result<String> {
+        Ok("svls".to_string())
+    }
+
+    fn asset_name(
+        version: &str,
+        os: zed_extension_api::Os,
+        arch: zed_extension_api::Architecture,
+    ) -> zed_extension_api::Result<String> {
+        Ok(match (os, arch) {
+            (zed::Os::Mac, zed::Architecture::Aarch64) => {
+                format!("svls-{version}-aarch64-mac.zip")
+            }
+            (zed::Os::Mac, zed::Architecture::X8664) => {
+                format!("svls-{version}-x86_64-mac.zip")
+            }
+            (zed::Os::Linux, zed::Architecture::X8664) => {
+                format!("svls-{version}-x86_64-lnx.zip")
+            }
+            (zed::Os::Windows, zed::Architecture::X8664) => {
+                format!("svls-{version}-x86_64-win.zip")
+            }
+            (os, arch) => {
+                return Err(format!("architecture {arch:?} not supported on {os:?}"));
+            }
+        })
+    }
+
+    // svls releases use zip for all platforms, unlike the default which uses GzipTar for Mac/Linux
+    fn download_binary(
+        &self,
+        language_server_id: &zed::LanguageServerId,
+        os: zed::Os,
+        arch: zed::Architecture,
+    ) -> zed::Result<String> {
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
+        );
+
+        let release = zed::github_release_by_tag_name(Self::DOWNLOAD_REPO, Self::DOWNLOAD_TAG)?;
+
+        let asset_name = Self::asset_name(&release.version, os, arch)?;
+        let asset = release
+            .assets
+            .into_iter()
+            .find(|asset| asset.name == asset_name)
+            .ok_or(format!("no asset found matching `{asset_name}`"))?;
+        let binary_path = Self::binary_path(&release.version, os, arch)?;
+
+        if !fs::metadata(&binary_path).is_ok_and(|metadata| metadata.is_file()) {
+            zed::set_language_server_installation_status(
+                language_server_id,
+                &zed::LanguageServerInstallationStatus::Downloading,
+            );
+
+            zed::download_file(&asset.download_url, "", zed::DownloadedFileType::Zip)
+                .map_err(|err| {
+                    format!("failed to download file `{}`: {err}", asset.download_url)
+                })?;
+        }
+
+        zed::set_language_server_installation_status(
+            language_server_id,
+            &zed::LanguageServerInstallationStatus::None,
+        );
+
+        Ok(binary_path)
+    }
+}

--- a/src/language_server/svls.rs
+++ b/src/language_server/svls.rs
@@ -88,10 +88,9 @@ impl LanguageServer for Svls {
                 &zed::LanguageServerInstallationStatus::Downloading,
             );
 
-            zed::download_file(&asset.download_url, "", zed::DownloadedFileType::Zip)
-                .map_err(|err| {
-                    format!("failed to download file `{}`: {err}", asset.download_url)
-                })?;
+            zed::download_file(&asset.download_url, "", zed::DownloadedFileType::Zip).map_err(
+                |err| format!("failed to download file `{}`: {err}", asset.download_url),
+            )?;
         }
 
         zed::set_language_server_installation_status(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,6 @@
-use language_server::{slang::Slang, svls::Svls, verible::Verible, veridian::Veridian, LanguageServer};
+use language_server::{
+    slang::Slang, svls::Svls, verible::Verible, veridian::Veridian, LanguageServer,
+};
 
 use zed::{LanguageServerId, Worktree};
 use zed_extension_api::{self as zed};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-use language_server::{slang::Slang, verible::Verible, veridian::Veridian, LanguageServer};
+use language_server::{slang::Slang, svls::Svls, verible::Verible, veridian::Veridian, LanguageServer};
 
 use zed::{LanguageServerId, Worktree};
 use zed_extension_api::{self as zed};
@@ -9,6 +9,7 @@ struct VerilogExtension {
     verible: Verible,
     veridian: Veridian,
     slang: Slang,
+    svls: Svls,
 }
 
 impl zed::Extension for VerilogExtension {
@@ -20,6 +21,7 @@ impl zed::Extension for VerilogExtension {
             verible: Default::default(),
             veridian: Default::default(),
             slang: Default::default(),
+            svls: Default::default(),
         }
     }
 
@@ -54,6 +56,11 @@ impl zed::Extension for VerilogExtension {
                     env: Vec::new(),
                 })
             }
+            Svls::LANGUAGE_SERVER_ID => Ok(zed::Command {
+                command: self.svls.get_binary(language_server_id, worktree)?,
+                args: Vec::new(),
+                env: Vec::new(),
+            }),
             id => Err(format!("unknown language server `{id}`"))?,
         }
     }


### PR DESCRIPTION
Adds support for [svls](https://github.com/dalance/svls). I've tested this locally and can confirm it works. Adding a custom `.svlint.toml` file also works.