### PR TITLE
Bump slang-server to 0.2.5

### DIFF
--- a/src/language_server/slang.rs
+++ b/src/language_server/slang.rs
@@ -9,7 +9,7 @@ pub struct Slang {
 impl LanguageServer for Slang {
     const LANGUAGE_SERVER_ID: &'static str = "slang";
     const DOWNLOAD_REPO: &'static str = "hudson-trading/slang-server";
-    const DOWNLOAD_TAG: &'static str = "v0.2.2";
+    const DOWNLOAD_TAG: &'static str = "v0.2.5";
 
     fn get_cached_binary(&self) -> Option<String> {
         self.cached_binary.clone()


### PR DESCRIPTION
Changes:
* Show macro expansions on hover
* Added "expand macro" code action
* Gotos/hovers for ifdefs and file defines
* Fix inlay hints for macro usages in function args
* Many bugfixes