### PR TITLE
Various asset name and path fixes

### DIFF
--- a/.github/workflows/build-veridian.yaml
+++ b/.github/workflows/build-veridian.yaml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Veridian
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: vivekmalneedi/veridian
 
@@ -38,7 +38,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout Veridian
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: vivekmalneedi/veridian
 
@@ -70,7 +70,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Veridian
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: vivekmalneedi/veridian
 
@@ -97,7 +97,7 @@ jobs:
     runs-on: macos-latest
     steps:
       - name: Checkout Veridian
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: vivekmalneedi/veridian
 
@@ -124,7 +124,7 @@ jobs:
     runs-on: "windows-latest"
     steps:
       - name: Checkout Veridian
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           repository: vivekmalneedi/veridian
 

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -9,6 +9,6 @@ jobs:
   pre-commit:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - uses: actions/setup-python@v3
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/rust-tests.yaml
+++ b/.github/workflows/rust-tests.yaml
@@ -1,0 +1,23 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install Rust Toolchain
+        uses: "dtolnay/rust-toolchain@v1"
+        with:
+          toolchain: stable
+
+      - name: Cache cargo build
+        uses: Swatinem/rust-cache@v2
+
+      - name: Run cargo test
+        run: cargo test

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -27,10 +27,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "base64"
+version = "0.22.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
+
+[[package]]
 name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
+
+[[package]]
+name = "bumpalo"
+version = "3.20.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
+
+[[package]]
+name = "cc"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89588d05638b5b4594a3348a2d6c20277e43a7f5c5202b05cc56888475a47b8"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
 
 [[package]]
 name = "cfg-if"
@@ -65,13 +87,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
-name = "flate2"
-version = "1.1.2"
+name = "errno"
+version = "0.3.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a3d7db9596fecd151c5f638c0ee5d5bd487b6e0ea232e5dc96d5250f6f94b1d"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
+ "zlib-rs",
 ]
 
 [[package]]
@@ -176,6 +231,28 @@ dependencies = [
  "pin-project-lite",
  "pin-utils",
  "slab",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
 ]
 
 [[package]]
@@ -337,6 +414,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
+name = "libc"
+version = "0.2.189"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3eaf3ede3fee6db1a4c2ee091bf8a8b4dccdc6d17f656fb07896ee72867612f2"
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -344,9 +433,9 @@ checksum = "241eaef5fd12c88705a01fc1066c48c4b36e0dd4377dcdc7ec3942cea7a69956"
 
 [[package]]
 name = "log"
-version = "0.4.22"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7a70ba024b9dc04c27ea2f0c0548feb474ec5c54bba33a7f72f873a39d07b24"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"
@@ -361,6 +450,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
 dependencies = [
  "adler2",
+ "simd-adler32",
 ]
 
 [[package]]
@@ -425,6 +515,74 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.42"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
+dependencies = [
+ "log",
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4925028c7eb5d1fcdaf196971378ed9d2c1c4efc7dc5d011256f76c99c0a96"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "ryu"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -482,6 +640,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a219298ac11a56ea9a6d2120044824d6f01aeb034955e7af7bc16858527deea"
+
+[[package]]
 name = "slab"
 version = "0.4.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -509,6 +679,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "syn"
 version = "2.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +707,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.3",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "tinystr"
 version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -547,6 +747,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea68304e134ecd095ac6c3574494fc62b909f416c4fca77e440530221e549d3d"
 
 [[package]]
+name = "typed-path"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e28f89b80c87b8fb0cf04ab448d5dd0dd0ade2f8891bae878de66a75a28600e"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +763,28 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
+name = "ureq"
+version = "2.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02d1a66277ed75f640d608235660df48c8e3c19f3b4edb6a263315626cc3c01d"
+dependencies = [
+ "base64",
+ "flate2",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-pki-types",
+ "url",
+ "webpki-roots 0.26.11",
+]
 
 [[package]]
 name = "url"
@@ -575,6 +803,12 @@ name = "utf8_iter"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
+
+[[package]]
+name = "wasi"
+version = "0.11.1+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasm-encoder"
@@ -616,6 +850,112 @@ dependencies = [
  "indexmap",
  "semver",
 ]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.9",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7dcd9d09a39985f5344844e66b0c530a33843579125f23e21e9f0f220850f22a"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
+dependencies = [
+ "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
+dependencies = [
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
+]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.52.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "wit-bindgen"
@@ -724,6 +1064,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
+
+[[package]]
 name = "yoke"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -751,7 +1101,12 @@ dependencies = [
 name = "zed-verilog-extension"
 version = "0.0.18"
 dependencies = [
+ "flate2",
+ "tar",
+ "tempfile",
+ "ureq",
  "zed_extension_api",
+ "zip",
 ]
 
 [[package]]
@@ -787,6 +1142,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13c156562582aa81c60cb29407084cdb54c4164760106ab78e6c5b0858cf64e"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -817,4 +1178,36 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "zip"
+version = "8.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
+dependencies = [
+ "crc32fast",
+ "flate2",
+ "indexmap",
+ "memchr",
+ "typed-path",
+ "zopfli",
+]
+
+[[package]]
+name = "zlib-rs"
+version = "0.6.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b142a20ec14a91d5bc708c1dc21b080c550113d8aa77afa29635673a65dd02c5"
+
+[[package]]
+name = "zopfli"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05cd8797d63865425ff89b5c4a48804f35ba0ce8d125800027ad6017d2b5249"
+dependencies = [
+ "bumpalo",
+ "crc32fast",
+ "log",
+ "simd-adler32",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,14 @@ license = "MIT OR Apache-2.0"
 publish = false
 
 [lib]
-crate-type = ["cdylib"]
+crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 zed_extension_api = "0.7.0"
+
+[dev-dependencies]
+flate2 = "1.1.9"
+tar = "0.4.46"
+tempfile = "3.27.0"
+ureq = "2"
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }

--- a/src/language_server/mod.rs
+++ b/src/language_server/mod.rs
@@ -17,6 +17,12 @@ pub trait LanguageServer {
     fn binary_name(os: zed::Os) -> String;
     fn binary_path(version: &str, os: zed::Os, arch: zed::Architecture) -> zed::Result<String>;
     fn asset_name(version: &str, os: zed::Os, arch: zed::Architecture) -> zed::Result<String>;
+    fn asset_type(os: zed::Os) -> zed::Result<zed::DownloadedFileType> {
+        Ok(match os {
+            zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
+            zed::Os::Windows => zed::DownloadedFileType::Zip,
+        })
+    }
 
     fn download_binary(
         &self,
@@ -59,15 +65,8 @@ pub trait LanguageServer {
             &zed::LanguageServerInstallationStatus::Downloading,
         );
 
-        zed::download_file(
-            &asset.download_url,
-            "",
-            match os {
-                zed::Os::Mac | zed::Os::Linux => zed::DownloadedFileType::GzipTar,
-                zed::Os::Windows => zed::DownloadedFileType::Zip,
-            },
-        )
-        .map_err(|err| format!("failed to download file `{}`: {err}", asset.download_url))?;
+        zed::download_file(&asset.download_url, "", Self::asset_type(os)?)
+            .map_err(|err| format!("failed to download file `{}`: {err}", asset.download_url))?;
 
         zed::set_language_server_installation_status(
             language_server_id,

--- a/src/language_server/slang.rs
+++ b/src/language_server/slang.rs
@@ -29,10 +29,10 @@ impl LanguageServer for Slang {
 
     fn binary_path(
         _version: &str,
-        _os: zed_extension_api::Os,
+        os: zed_extension_api::Os,
         _arch: zed_extension_api::Architecture,
     ) -> zed_extension_api::Result<String> {
-        Ok("slang-server".to_string())
+        Ok(Self::binary_name(os))
     }
 
     fn asset_name(

--- a/src/language_server/svls.rs
+++ b/src/language_server/svls.rs
@@ -1,5 +1,4 @@
 use super::LanguageServer;
-use std::fs;
 use zed_extension_api::{self as zed};
 
 #[derive(Default)]
@@ -55,44 +54,9 @@ impl LanguageServer for Svls {
         Ok(format!("svls-{version}-{target}.zip"))
     }
 
-    // svls releases use zip for all platforms, unlike the default which uses GzipTar for Mac/Linux
-    fn download_binary(
-        &self,
-        language_server_id: &zed::LanguageServerId,
-        os: zed::Os,
-        arch: zed::Architecture,
-    ) -> zed::Result<String> {
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::CheckingForUpdate,
-        );
-
-        let release = zed::github_release_by_tag_name(Self::DOWNLOAD_REPO, Self::DOWNLOAD_TAG)?;
-
-        let asset_name = Self::asset_name(&release.version, os, arch)?;
-        let asset = release
-            .assets
-            .into_iter()
-            .find(|asset| asset.name == asset_name)
-            .ok_or(format!("no asset found matching `{asset_name}`"))?;
-        let binary_path = Self::binary_path(&release.version, os, arch)?;
-
-        if !fs::metadata(&binary_path).is_ok_and(|metadata| metadata.is_file()) {
-            zed::set_language_server_installation_status(
-                language_server_id,
-                &zed::LanguageServerInstallationStatus::Downloading,
-            );
-
-            zed::download_file(&asset.download_url, "", zed::DownloadedFileType::Zip).map_err(
-                |err| format!("failed to download file `{}`: {err}", asset.download_url),
-            )?;
-        }
-
-        zed::set_language_server_installation_status(
-            language_server_id,
-            &zed::LanguageServerInstallationStatus::None,
-        );
-
-        Ok(binary_path)
+    fn asset_type(
+        _os: zed_extension_api::Os,
+    ) -> zed_extension_api::Result<zed_extension_api::DownloadedFileType> {
+        Ok(zed_extension_api::DownloadedFileType::Zip)
     }
 }

--- a/src/language_server/svls.rs
+++ b/src/language_server/svls.rs
@@ -30,10 +30,14 @@ impl LanguageServer for Svls {
 
     fn binary_path(
         _version: &str,
-        _os: zed_extension_api::Os,
+        os: zed_extension_api::Os,
         _arch: zed_extension_api::Architecture,
     ) -> zed_extension_api::Result<String> {
-        Ok("svls".to_string())
+        Ok(match os {
+            zed_extension_api::Os::Windows => "target/x86_64-pc-windows-msvc/release/svls.exe",
+            _ => "svls",
+        }
+        .to_string())
     }
 
     fn asset_name(
@@ -41,23 +45,14 @@ impl LanguageServer for Svls {
         os: zed_extension_api::Os,
         arch: zed_extension_api::Architecture,
     ) -> zed_extension_api::Result<String> {
-        Ok(match (os, arch) {
-            (zed::Os::Mac, zed::Architecture::Aarch64) => {
-                format!("svls-{version}-aarch64-mac.zip")
-            }
-            (zed::Os::Mac, zed::Architecture::X8664) => {
-                format!("svls-{version}-x86_64-mac.zip")
-            }
-            (zed::Os::Linux, zed::Architecture::X8664) => {
-                format!("svls-{version}-x86_64-lnx.zip")
-            }
-            (zed::Os::Windows, zed::Architecture::X8664) => {
-                format!("svls-{version}-x86_64-win.zip")
-            }
-            (os, arch) => {
-                return Err(format!("architecture {arch:?} not supported on {os:?}"));
-            }
-        })
+        let target = match (os, arch) {
+            (zed::Os::Mac, zed::Architecture::Aarch64) => "aarch64-mac",
+            (zed::Os::Mac, zed::Architecture::X8664) => "x86_64-mac",
+            (zed::Os::Linux, zed::Architecture::X8664) => "x86_64-lnx",
+            (zed::Os::Windows, zed::Architecture::X8664) => "x86_64-win",
+            (os, arch) => return Err(format!("architecture {arch:?} not supported on {os:?}")),
+        };
+        Ok(format!("svls-{version}-{target}.zip"))
     }
 
     // svls releases use zip for all platforms, unlike the default which uses GzipTar for Mac/Linux

--- a/src/language_server/verible.rs
+++ b/src/language_server/verible.rs
@@ -33,7 +33,7 @@ impl LanguageServer for Verible {
             match os {
                 zed::Os::Mac => "-macOS/bin",
                 zed::Os::Linux => "/bin",
-                zed::Os::Windows => "-win64/",
+                zed::Os::Windows => "-win64",
             }
         );
         let binary_name = Self::binary_name(os);

--- a/src/language_server/veridian.rs
+++ b/src/language_server/veridian.rs
@@ -29,10 +29,10 @@ impl LanguageServer for Veridian {
 
     fn binary_path(
         _version: &str,
-        _os: zed_extension_api::Os,
+        os: zed_extension_api::Os,
         _arch: zed_extension_api::Architecture,
     ) -> zed_extension_api::Result<String> {
-        Ok("veridian".to_string())
+        Ok(Self::binary_name(os))
     }
 
     fn asset_name(
@@ -42,7 +42,7 @@ impl LanguageServer for Veridian {
     ) -> zed_extension_api::Result<String> {
         Ok(match (os, arch) {
             (zed::Os::Mac, zed::Architecture::Aarch64) => "veridian-aarch64-macos.tar.gz",
-            (zed::Os::Mac, zed::Architecture::X8664) => "veridian-aarch64-x86_64-macos.tar.gz",
+            (zed::Os::Mac, zed::Architecture::X8664) => "veridian-x86_64-macos.tar.gz",
             (zed::Os::Linux, zed::Architecture::Aarch64) => "veridian-aarch64-linux-musl.tar.gz",
             (zed::Os::Linux, zed::Architecture::X8664) => "veridian-x86_64-linux-musl.tar.gz",
             (zed::Os::Windows, zed::Architecture::X8664) => "veridian-x86_64-windows-mscv.zip",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ use language_server::{
 use zed::{LanguageServerId, Worktree};
 use zed_extension_api::{self as zed};
 
-mod language_server;
+pub mod language_server;
 
 struct VerilogExtension {
     verible: Verible,

--- a/tests/release_assets.rs
+++ b/tests/release_assets.rs
@@ -1,0 +1,211 @@
+use std::collections::HashMap;
+use std::io::{Cursor, Read};
+use std::path::{Component, Path};
+
+use flate2::read::GzDecoder;
+use zed_extension_api::{Architecture, DownloadedFileType, Os};
+use zed_verilog_extension::language_server::{
+    slang::Slang, svls::Svls, verible::Verible, veridian::Veridian, LanguageServer,
+};
+
+const ALL_PLATFORMS: &[(Os, Architecture)] = &[
+    (Os::Mac, Architecture::Aarch64),
+    (Os::Mac, Architecture::X8664),
+    (Os::Mac, Architecture::X86),
+    (Os::Linux, Architecture::Aarch64),
+    (Os::Linux, Architecture::X8664),
+    (Os::Linux, Architecture::X86),
+    (Os::Windows, Architecture::Aarch64),
+    (Os::Windows, Architecture::X8664),
+    (Os::Windows, Architecture::X86),
+];
+
+#[test]
+fn verible_release_assets() {
+    verify_release_assets::<Verible>();
+}
+
+#[test]
+fn slang_release_assets() {
+    verify_release_assets::<Slang>();
+}
+
+#[test]
+fn veridian_release_assets() {
+    let tag = resolve_tag_with_previous_fallback::<Veridian>()
+        .unwrap_or_else(|err| panic!("failed to resolve veridian release tag: {err}"));
+    verify_release_assets_against_tag::<Veridian>(&tag);
+}
+
+#[test]
+fn svls_release_assets() {
+    verify_release_assets::<Svls>();
+}
+
+fn verify_release_assets<S: LanguageServer>() {
+    verify_release_assets_against_tag::<S>(S::DOWNLOAD_TAG);
+}
+
+fn verify_release_assets_against_tag<S: LanguageServer>(tag: &str) {
+    let mut assets: HashMap<String, Vec<u8>> = HashMap::new();
+    let mut supported = 0;
+    let mut errors = Vec::new();
+
+    for &(os, arch) in ALL_PLATFORMS {
+        let Ok(asset_name) = S::asset_name(tag, os, arch) else {
+            continue;
+        };
+        supported += 1;
+
+        if let Err(err) = verify_asset::<S>(
+            os,
+            arch,
+            tag,
+            &asset_name,
+            S::asset_type(os).unwrap(),
+            &mut assets,
+        ) {
+            errors.push(format!("{os:?}/{arch:?} ({asset_name}): {err}"));
+        }
+    }
+
+    assert!(
+        supported > 0,
+        "`{}` supports no platforms",
+        S::LANGUAGE_SERVER_ID
+    );
+    assert!(
+        errors.is_empty(),
+        "release asset checks failed for `{}`:\n  {}",
+        S::LANGUAGE_SERVER_ID,
+        errors.join("\n  ")
+    );
+}
+
+fn verify_asset<S: LanguageServer>(
+    os: Os,
+    arch: Architecture,
+    tag: &str,
+    asset_name: &str,
+    file_type: DownloadedFileType,
+    assets: &mut HashMap<String, Vec<u8>>,
+) -> Result<(), String> {
+    let binary_path = S::binary_path(tag, os, arch)?;
+    let relative = Path::new(&binary_path);
+    if relative.is_absolute()
+        || relative
+            .components()
+            .any(|component| matches!(component, Component::ParentDir))
+    {
+        return Err(format!(
+            "binary path `{binary_path}` escapes the extension's work directory"
+        ));
+    }
+
+    let url = download_url(S::DOWNLOAD_REPO, tag, asset_name);
+    if !assets.contains_key(&url) {
+        let bytes = download(&url)?;
+        assets.insert(url.clone(), bytes);
+    }
+    let archive = &assets[&url];
+
+    let dir = tempfile::tempdir().map_err(|err| format!("failed to create temp dir: {err}"))?;
+    extract(archive, file_type, dir.path())?;
+
+    let binary = dir.path().join(relative);
+    let metadata = std::fs::metadata(&binary)
+        .map_err(|err| format!("no binary at `{binary_path}` after extraction: {err}"))?;
+    if !metadata.is_file() {
+        return Err(format!("`{binary_path}` is not a regular file"));
+    }
+
+    if matches!(os, Os::Mac | Os::Linux) {
+        check_executable(&metadata, &binary_path)?;
+    }
+
+    Ok(())
+}
+
+#[cfg(unix)]
+fn check_executable(metadata: &std::fs::Metadata, binary_path: &str) -> Result<(), String> {
+    use std::os::unix::fs::PermissionsExt;
+
+    let mode = metadata.permissions().mode();
+    if mode & 0o111 == 0 {
+        return Err(format!("`{binary_path}` is not executable (mode {mode:o})"));
+    }
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn check_executable(_metadata: &std::fs::Metadata, _binary_path: &str) -> Result<(), String> {
+    Ok(())
+}
+
+fn resolve_tag_with_previous_fallback<S: LanguageServer>() -> Result<String, String> {
+    let current = S::DOWNLOAD_TAG;
+    let Some(previous) = previous_patch_tag(current) else {
+        return Ok(current.to_string());
+    };
+
+    for &(os, arch) in ALL_PLATFORMS {
+        let Ok(asset_name) = S::asset_name(current, os, arch) else {
+            continue;
+        };
+        if asset_exists(&download_url(S::DOWNLOAD_REPO, current, &asset_name))? {
+            return Ok(current.to_string());
+        }
+    }
+
+    eprintln!(
+        "no assets published for `{}` at `{current}`; checking previous release `{previous}` instead",
+        S::LANGUAGE_SERVER_ID
+    );
+    Ok(previous)
+}
+
+fn previous_patch_tag(tag: &str) -> Option<String> {
+    let (rest, patch) = tag.rsplit_once('.')?;
+    let previous = patch.parse::<u32>().ok()?.checked_sub(1)?;
+    Some(format!("{rest}.{previous}"))
+}
+
+fn download_url(repo: &str, tag: &str, asset_name: &str) -> String {
+    format!("https://github.com/{repo}/releases/download/{tag}/{asset_name}")
+}
+
+fn asset_exists(url: &str) -> Result<bool, String> {
+    match ureq::head(url).call() {
+        Ok(_) => Ok(true),
+        Err(ureq::Error::Status(404, _)) => Ok(false),
+        Err(err) => Err(format!("failed to check `{url}`: {err}")),
+    }
+}
+
+fn download(url: &str) -> Result<Vec<u8>, String> {
+    let response = ureq::get(url)
+        .call()
+        .map_err(|err| format!("failed to download `{url}`: {err}"))?;
+
+    let mut bytes = Vec::new();
+    response
+        .into_reader()
+        .read_to_end(&mut bytes)
+        .map_err(|err| format!("failed to read `{url}`: {err}"))?;
+
+    Ok(bytes)
+}
+
+fn extract(archive: &[u8], file_type: DownloadedFileType, dest: &Path) -> Result<(), String> {
+    match file_type {
+        DownloadedFileType::GzipTar => tar::Archive::new(GzDecoder::new(archive))
+            .unpack(dest)
+            .map_err(|err| format!("failed to extract tar.gz: {err}")),
+        DownloadedFileType::Zip => zip::ZipArchive::new(Cursor::new(archive))
+            .and_then(|mut zip| zip.extract(dest))
+            .map_err(|err| format!("failed to extract zip: {err}")),
+        DownloadedFileType::Gzip | DownloadedFileType::Uncompressed => {
+            Err(format!("unexpected file type {file_type:?}"))
+        }
+    }
+}


### PR DESCRIPTION
- Fixes a few asset paths which were incorrect (closes #29)
- Refactors svls download code to use the use the common download implementation (which also moves the binary check to before fetching available assets)
- Added a test which verifies all assets exist on github and have binaries in the places claimed